### PR TITLE
Proxy handling

### DIFF
--- a/mobile/android/base/CrashReporter.java
+++ b/mobile/android/base/CrashReporter.java
@@ -17,13 +17,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.Proxy;
-import java.net.InetSocketAddress;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.util.zip.GZIPOutputStream;
 
 import org.mozilla.gecko.AppConstants.Versions;
+import org.mozilla.gecko.util.ProxySettings;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -354,8 +353,7 @@ public class CrashReporter extends Activity
         Log.i(LOGTAG, "server url: " + spec);
         try {
             URL url = new URL(spec);
-            Proxy torProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
-            HttpURLConnection conn = (HttpURLConnection)url.openConnection(torProxy);
+            HttpURLConnection conn = (HttpURLConnection)url.openConnection(ProxySettings.getProxy());
             conn.setRequestMethod("POST");
             String boundary = generateBoundary();
             conn.setDoOutput(true);

--- a/mobile/android/base/SuggestClient.java
+++ b/mobile/android/base/SuggestClient.java
@@ -7,8 +7,6 @@ package org.mozilla.gecko;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.Proxy;
-import java.net.InetSocketAddress;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -16,6 +14,7 @@ import java.util.ArrayList;
 
 import org.json.JSONArray;
 import org.mozilla.gecko.mozglue.RobocopTarget;
+import org.mozilla.gecko.util.ProxySettings;
 import org.mozilla.gecko.util.HardwareUtils;
 
 import android.content.Context;
@@ -86,8 +85,7 @@ public class SuggestClient {
             HttpURLConnection urlConnection = null;
             InputStream in = null;
             try {
-                Proxy torProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
-                urlConnection = (HttpURLConnection) url.openConnection(torProxy);
+                urlConnection = (HttpURLConnection) url.openConnection(ProxySettings.getProxy());
                 urlConnection.setConnectTimeout(mTimeout);
                 urlConnection.setRequestProperty("User-Agent", USER_AGENT);
                 in = new BufferedInputStream(urlConnection.getInputStream());

--- a/mobile/android/base/background/bagheera/BagheeraClient.java
+++ b/mobile/android/base/background/bagheera/BagheeraClient.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.background.bagheera;
 
+import android.content.Context;
+
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
@@ -32,6 +34,7 @@ import ch.boye.httpclientandroidlib.protocol.HTTP;
  */
 public class BagheeraClient {
 
+  protected final Context mCtx;
   protected final String serverURI;
   protected final Executor executor;
   protected static final Pattern URI_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
@@ -51,13 +54,14 @@ public class BagheeraClient {
    * @param executor
    *          the executor which will be used to invoke delegate callbacks.
    */
-  public BagheeraClient(final String serverURI, final Executor executor) {
+  public BagheeraClient(final Context ctx, final String serverURI, final Executor executor) {
     if (serverURI == null) {
       throw new IllegalArgumentException("Must provide a server URI.");
     }
     if (executor == null) {
       throw new IllegalArgumentException("Must provide a non-null executor.");
     }
+    this.mCtx = ctx;
     this.serverURI = serverURI.endsWith("/") ? serverURI : serverURI + "/";
     this.executor = executor;
   }
@@ -71,8 +75,8 @@ public class BagheeraClient {
    * @param serverURI
    *          the destination server URI.
    */
-  public BagheeraClient(final String serverURI) {
-    this(serverURI, Executors.newSingleThreadExecutor());
+  public BagheeraClient(final Context ctx, final String serverURI) {
+    this(ctx, serverURI, Executors.newSingleThreadExecutor());
   }
 
   /**
@@ -147,7 +151,7 @@ public class BagheeraClient {
 
     final String uri = this.serverURI + PROTOCOL_VERSION + SUBMIT_PATH +
                        namespace + "/" + id;
-    return new BaseResource(uri);
+    return new BaseResource(mCtx, uri);
   }
 
   public class BagheeraResourceDelegate extends BaseResourceDelegate {

--- a/mobile/android/base/background/fxa/FxAccountClient10.java
+++ b/mobile/android/base/background/fxa/FxAccountClient10.java
@@ -20,6 +20,8 @@ import java.util.concurrent.Executor;
 
 import javax.crypto.Mac;
 
+import android.content.Context;
+
 import org.json.simple.JSONObject;
 import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClientMalformedResponseException;
 import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClientRemoteException;
@@ -77,6 +79,8 @@ public class FxAccountClient10 {
   protected static final String[] requiredErrorStringFields = { JSON_KEY_ERROR, JSON_KEY_MESSAGE, JSON_KEY_INFO };
   protected static final String[] requiredErrorLongFields = { JSON_KEY_CODE, JSON_KEY_ERRNO };
 
+  protected final Context mCtx;
+
   /**
    * The server's URI.
    * <p>
@@ -87,13 +91,14 @@ public class FxAccountClient10 {
 
   protected final Executor executor;
 
-  public FxAccountClient10(String serverURI, Executor executor) {
+  public FxAccountClient10(Context ctx, String serverURI, Executor executor) {
     if (serverURI == null) {
       throw new IllegalArgumentException("Must provide a server URI.");
     }
     if (executor == null) {
       throw new IllegalArgumentException("Must provide a non-null executor.");
     }
+    this.mCtx = ctx;
     this.serverURI = serverURI.endsWith("/") ? serverURI : serverURI + "/";
     if (!this.serverURI.endsWith("/")) {
       throw new IllegalArgumentException("Constructed serverURI must end with a trailing slash: " + this.serverURI);
@@ -140,7 +145,7 @@ public class FxAccountClient10 {
         sb.append(URLEncoder.encode(val, "UTF-8"));
       }
     }
-    return new BaseResource(new URI(sb.toString()));
+    return new BaseResource(mCtx, new URI(sb.toString()));
   }
 
   /**

--- a/mobile/android/base/background/fxa/FxAccountClient20.java
+++ b/mobile/android/base/background/fxa/FxAccountClient20.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
+import android.content.Context;
+
 import org.json.simple.JSONObject;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.background.fxa.FxAccountClientException.FxAccountClientRemoteException;
@@ -22,8 +24,8 @@ public class FxAccountClient20 extends FxAccountClient10 implements FxAccountCli
   protected static final String[] LOGIN_RESPONSE_REQUIRED_STRING_FIELDS_KEYS = new String[] { JSON_KEY_UID, JSON_KEY_SESSIONTOKEN, JSON_KEY_KEYFETCHTOKEN, };
   protected static final String[] LOGIN_RESPONSE_REQUIRED_BOOLEAN_FIELDS = new String[] { JSON_KEY_VERIFIED };
 
-  public FxAccountClient20(String serverURI, Executor executor) {
-    super(serverURI, executor);
+  public FxAccountClient20(Context ctx, String serverURI, Executor executor) {
+    super(ctx, serverURI, executor);
   }
 
   /**

--- a/mobile/android/base/background/fxa/oauth/FxAccountOAuthClient10.java
+++ b/mobile/android/base/background/fxa/oauth/FxAccountOAuthClient10.java
@@ -8,6 +8,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.Executor;
 
+import android.content.Context;
+
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.net.BaseResource;
 
@@ -59,10 +61,10 @@ public class FxAccountOAuthClient10 extends FxAccountAbstractClient {
   }
 
   public void authorization(String client_id, String assertion, String state, String scope,
-                            RequestDelegate<AuthorizationResponse> delegate) {
+                            RequestDelegate<AuthorizationResponse> delegate, Context context) {
     final BaseResource resource;
     try {
-      resource = new BaseResource(new URI(serverURI + "authorization"));
+      resource = new BaseResource(context, new URI(serverURI + "authorization"));
     } catch (URISyntaxException e) {
       invokeHandleError(delegate, e);
       return;

--- a/mobile/android/base/background/fxa/profile/FxAccountProfileClient10.java
+++ b/mobile/android/base/background/fxa/profile/FxAccountProfileClient10.java
@@ -8,6 +8,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.Executor;
 
+import android.content.Context;
+
 import org.mozilla.gecko.background.fxa.oauth.FxAccountAbstractClient;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
@@ -27,10 +29,10 @@ public class FxAccountProfileClient10 extends FxAccountAbstractClient {
     super(serverURI, executor);
   }
 
-  public void profile(final String token, RequestDelegate<ExtendedJSONObject> delegate) {
+  public void profile(final String token, RequestDelegate<ExtendedJSONObject> delegate, Context context) {
     BaseResource resource;
     try {
-      resource = new BaseResource(new URI(serverURI + "profile"));
+      resource = new BaseResource(context, new URI(serverURI + "profile"));
     } catch (URISyntaxException e) {
       invokeHandleError(delegate, e);
       return;

--- a/mobile/android/base/background/healthreport/upload/AndroidSubmissionClient.java
+++ b/mobile/android/base/background/healthreport/upload/AndroidSubmissionClient.java
@@ -100,7 +100,7 @@ public class AndroidSubmissionClient implements SubmissionClient {
   }
 
   protected void uploadPayload(String id, String payload, Collection<String> oldIds, BagheeraRequestDelegate uploadDelegate) {
-    final BagheeraClient client = new BagheeraClient(getDocumentServerURI());
+    final BagheeraClient client = new BagheeraClient(context, getDocumentServerURI());
 
     Logger.pii(LOG_TAG, "New health report has id " + id +
         "and obsoletes " + (oldIds != null ? Integer.toString(oldIds.size()) : "no") + " old ids.");
@@ -186,7 +186,7 @@ public class AndroidSubmissionClient implements SubmissionClient {
 
   @Override
   public void delete(final long localTime, final String id, Delegate delegate) {
-    final BagheeraClient client = new BagheeraClient(getDocumentServerURI());
+    final BagheeraClient client = new BagheeraClient(context, getDocumentServerURI());
 
     Logger.pii(LOG_TAG, "Deleting health report with id " + id + ".");
 

--- a/mobile/android/base/browserid/verifier/BrowserIDRemoteVerifierClient10.java
+++ b/mobile/android/base/browserid/verifier/BrowserIDRemoteVerifierClient10.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.browserid.verifier;
 
+import android.content.Context;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -25,12 +27,16 @@ public class BrowserIDRemoteVerifierClient10 extends AbstractBrowserIDRemoteVeri
 
   public static final String DEFAULT_VERIFIER_URL = "https://verifier.login.persona.org/verify";
 
-  public BrowserIDRemoteVerifierClient10() throws URISyntaxException {
+  private final Context mCtx;
+
+  public BrowserIDRemoteVerifierClient10(Context ctx) throws URISyntaxException {
     super(new URI(DEFAULT_VERIFIER_URL));
+    mCtx = ctx;
   }
 
-  public BrowserIDRemoteVerifierClient10(URI verifierUri) {
+  public BrowserIDRemoteVerifierClient10(Context ctx, URI verifierUri) {
     super(verifierUri);
+    mCtx = ctx;
   }
 
   @Override
@@ -45,7 +51,7 @@ public class BrowserIDRemoteVerifierClient10 extends AbstractBrowserIDRemoteVeri
       throw new IllegalArgumentException("delegate cannot be null.");
     }
 
-    BaseResource r = new BaseResource(verifierUri);
+    BaseResource r = new BaseResource(mCtx, verifierUri);
 
     r.delegate = new RemoteVerifierResourceDelegate(r, delegate);
 

--- a/mobile/android/base/browserid/verifier/BrowserIDRemoteVerifierClient20.java
+++ b/mobile/android/base/browserid/verifier/BrowserIDRemoteVerifierClient20.java
@@ -6,6 +6,7 @@ package org.mozilla.gecko.browserid.verifier;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import android.content.Context;
 
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 import org.mozilla.gecko.sync.net.BaseResource;
@@ -22,12 +23,16 @@ public class BrowserIDRemoteVerifierClient20 extends AbstractBrowserIDRemoteVeri
   protected static final String JSON_KEY_ASSERTION = "assertion";
   protected static final String JSON_KEY_AUDIENCE = "audience";
 
-  public BrowserIDRemoteVerifierClient20() throws URISyntaxException {
+  private final Context mCtx;
+
+  public BrowserIDRemoteVerifierClient20(Context ctx) throws URISyntaxException {
     super(new URI(DEFAULT_VERIFIER_URL));
+    mCtx = ctx;
   }
 
-  public BrowserIDRemoteVerifierClient20(URI verifierUri) {
+  public BrowserIDRemoteVerifierClient20(Context ctx, URI verifierUri) {
     super(verifierUri);
+    mCtx = ctx;
   }
 
   @Override
@@ -42,7 +47,7 @@ public class BrowserIDRemoteVerifierClient20 extends AbstractBrowserIDRemoteVeri
       throw new IllegalArgumentException("delegate cannot be null.");
     }
 
-    BaseResource r = new BaseResource(verifierUri);
+    BaseResource r = new BaseResource(mCtx, verifierUri);
     r.delegate = new RemoteVerifierResourceDelegate(r, delegate);
 
     final ExtendedJSONObject requestBody = new ExtendedJSONObject();

--- a/mobile/android/base/distribution/Distribution.java
+++ b/mobile/android/base/distribution/Distribution.java
@@ -18,8 +18,6 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.net.Proxy;
-import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -44,6 +42,7 @@ import org.mozilla.gecko.GeckoEvent;
 import org.mozilla.gecko.GeckoSharedPrefs;
 import org.mozilla.gecko.Telemetry;
 import org.mozilla.gecko.mozglue.RobocopTarget;
+import org.mozilla.gecko.util.ProxySettings;
 import org.mozilla.gecko.util.FileUtils;
 import org.mozilla.gecko.util.HardwareUtils;
 import org.mozilla.gecko.util.ThreadUtils;
@@ -469,8 +468,7 @@ public class Distribution {
         Log.v(LOGTAG, "Downloading referred distribution: " + uri);
 
         try {
-            Proxy torProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
-            final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection(torProxy);
+            final HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection(ProxySettings.getProxy());
 
             // If the Search Activity starts, and we handle the referrer intent, this'll return
             // null. Recover gracefully in this case.

--- a/mobile/android/base/fxa/activities/FxAccountAbstractUpdateCredentialsActivity.java
+++ b/mobile/android/base/fxa/activities/FxAccountAbstractUpdateCredentialsActivity.java
@@ -161,7 +161,7 @@ public abstract class FxAccountAbstractUpdateCredentialsActivity extends FxAccou
   public void updateCredentials(String email, String password) {
     String serverURI = fxAccount.getAccountServerURI();
     Executor executor = Executors.newSingleThreadExecutor();
-    FxAccountClient client = new FxAccountClient20(serverURI, executor);
+    FxAccountClient client = new FxAccountClient20(this, serverURI, executor);
     PasswordStretcher passwordStretcher = makePasswordStretcher(password);
     try {
       hideRemoteError();

--- a/mobile/android/base/fxa/activities/FxAccountCreateAccountActivity.java
+++ b/mobile/android/base/fxa/activities/FxAccountCreateAccountActivity.java
@@ -386,7 +386,7 @@ public class FxAccountCreateAccountActivity extends FxAccountAbstractSetupActivi
     };
 
     Executor executor = Executors.newSingleThreadExecutor();
-    FxAccountClient client = new FxAccountClient20(serverURI, executor);
+    FxAccountClient client = new FxAccountClient20(this, serverURI, executor);
     try {
       hideRemoteError();
       new FxAccountCreateAccountTask(this, this, email, passwordStretcher, client, getQueryParameters(), delegate).execute();

--- a/mobile/android/base/fxa/activities/FxAccountSignInActivity.java
+++ b/mobile/android/base/fxa/activities/FxAccountSignInActivity.java
@@ -109,7 +109,7 @@ public class FxAccountSignInActivity extends FxAccountAbstractSetupActivity {
     };
 
     Executor executor = Executors.newSingleThreadExecutor();
-    FxAccountClient client = new FxAccountClient20(serverURI, executor);
+    FxAccountClient client = new FxAccountClient20(this, serverURI, executor);
     try {
       hideRemoteError();
       new FxAccountSignInTask(this, this, email, passwordStretcher, client, getQueryParameters(), delegate).execute();

--- a/mobile/android/base/fxa/authenticator/FxADefaultLoginStateMachineDelegate.java
+++ b/mobile/android/base/fxa/authenticator/FxADefaultLoginStateMachineDelegate.java
@@ -35,7 +35,7 @@ public abstract class FxADefaultLoginStateMachineDelegate implements LoginStateM
     this.context = context;
     this.fxAccount = fxAccount;
     this.executor = Executors.newSingleThreadExecutor();
-    this.client = new FxAccountClient20(fxAccount.getAccountServerURI(), executor);
+    this.client = new FxAccountClient20(context, fxAccount.getAccountServerURI(), executor);
   }
 
   abstract public void handleNotMarried(State notMarried);

--- a/mobile/android/base/fxa/authenticator/FxAccountAuthenticator.java
+++ b/mobile/android/base/fxa/authenticator/FxAccountAuthenticator.java
@@ -130,7 +130,7 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
       this.context = context;
       this.fxAccount = fxAccount;
       this.executor = Executors.newSingleThreadExecutor();
-      this.client = new FxAccountClient20(fxAccount.getAccountServerURI(), executor);
+      this.client = new FxAccountClient20(context, fxAccount.getAccountServerURI(), executor);
     }
 
     @Override
@@ -253,7 +253,7 @@ public class FxAccountAuthenticator extends AbstractAccountAuthenticator {
             Logger.error(LOG_TAG, "OAuth error.", e);
             responder.fail(e);
           }
-        });
+        }, context);
       }
     });
   }

--- a/mobile/android/base/fxa/sync/FxAccountSyncAdapter.java
+++ b/mobile/android/base/fxa/sync/FxAccountSyncAdapter.java
@@ -311,7 +311,7 @@ public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
           final AuthHeaderProvider authHeaderProvider = new HawkAuthHeaderProvider(token.id, token.key.getBytes("UTF-8"), includePayloadVerificationHash, storageServerSkew);
 
           final Context context = getContext();
-          final SyncConfiguration syncConfig = new SyncConfiguration(token.uid, authHeaderProvider, sharedPrefs, syncKeyBundle);
+          final SyncConfiguration syncConfig = new SyncConfiguration(token.uid, authHeaderProvider, context, sharedPrefs, syncKeyBundle);
 
           Collection<String> knownStageNames = SyncConfiguration.validEngineNames();
           syncConfig.stagesToSync = Utils.getStagesToSyncFromBundle(knownStageNames, extras);
@@ -365,7 +365,7 @@ public class FxAccountSyncAdapter extends AbstractThreadedSyncAdapter {
     };
 
     TokenServerClient tokenServerclient = new TokenServerClient(tokenServerEndpointURI, executor);
-    tokenServerclient.getTokenFromBrowserIDAssertion(assertion, true, clientState, delegate);
+    tokenServerclient.getTokenFromBrowserIDAssertion(assertion, true, clientState, delegate, getContext());
   }
 
   /**

--- a/mobile/android/base/fxa/tasks/FxAccountCodeResender.java
+++ b/mobile/android/base/fxa/tasks/FxAccountCodeResender.java
@@ -103,7 +103,7 @@ public class FxAccountCodeResender {
     }
 
     Executor executor = Executors.newSingleThreadExecutor();
-    FxAccountClient client = new FxAccountClient20(fxAccount.getAccountServerURI(), executor);
+    FxAccountClient client = new FxAccountClient20(context, fxAccount.getAccountServerURI(), executor);
     new FxAccountResendCodeTask(context, sessionToken, client, delegate).execute();
   }
 }

--- a/mobile/android/base/fxa/tasks/FxAccountUnlockCodeResender.java
+++ b/mobile/android/base/fxa/tasks/FxAccountUnlockCodeResender.java
@@ -99,7 +99,7 @@ public class FxAccountUnlockCodeResender {
     }
 
     final Executor executor = Executors.newSingleThreadExecutor();
-    final FxAccountClient client = new FxAccountClient20(authServerURI, executor);
+    final FxAccountClient client = new FxAccountClient20(context, authServerURI, executor);
     new FxAccountUnlockCodeTask(context, emailUTF8, client, delegate).execute();
   }
 }

--- a/mobile/android/base/moz.build
+++ b/mobile/android/base/moz.build
@@ -78,7 +78,9 @@ gujar.sources += [
     'util/NativeJSObject.java',
     'util/NonEvictingLruCache.java',
     'util/PrefUtils.java',
+    'util/ProxyRoutePlanner.java',
     'util/ProxySelector.java',
+    'util/ProxySettings.java',
     'util/RawResource.java',
     'util/StringUtils.java',
     'util/ThreadUtils.java',
@@ -89,6 +91,7 @@ gujar.sources += [
 gujar.extra_jars = [
     'constants.jar',
     'gecko-mozglue.jar',
+    'sync-thirdparty.jar',
 ]
 gujar.javac_flags += ['-Xlint:all,-deprecation']
 

--- a/mobile/android/base/reading/ReadingListSyncAdapter.java
+++ b/mobile/android/base/reading/ReadingListSyncAdapter.java
@@ -134,7 +134,7 @@ public class ReadingListSyncAdapter extends AbstractThreadedSyncAdapter {
     final AuthHeaderProvider auth = new BearerAuthHeaderProvider(authToken);
 
     final PrefsBranch branch = new PrefsBranch(sharedPrefs, "readinglist.");
-    final ReadingListClient remote = new ReadingListClient(endpoint, auth);
+    final ReadingListClient remote = new ReadingListClient(context, endpoint, auth);
     final ContentProviderClient cpc = getContentProviderClient(context); // Released by the inner SyncAdapterSynchronizerDelegate.
 
     final LocalReadingListStorage local = new LocalReadingListStorage(cpc);

--- a/mobile/android/base/sync/GlobalSession.java
+++ b/mobile/android/base/sync/GlobalSession.java
@@ -520,7 +520,7 @@ public class GlobalSession implements HttpResponseObserver {
   }
 
   public void fetchInfoCollections(JSONRecordFetchDelegate callback) throws URISyntaxException {
-    final JSONRecordFetcher fetcher = new JSONRecordFetcher(config.infoCollectionsURL(), getAuthHeaderProvider());
+    final JSONRecordFetcher fetcher = new JSONRecordFetcher(getContext(), config.infoCollectionsURL(), getAuthHeaderProvider());
     fetcher.fetch(callback);
   }
 
@@ -536,7 +536,7 @@ public class GlobalSession implements HttpResponseObserver {
                          final KeyUploadDelegate keyUploadDelegate) {
     SyncStorageRecordRequest request;
     try {
-      request = new SyncStorageRecordRequest(this.config.keysURI());
+      request = new SyncStorageRecordRequest(getContext(), this.config.keysURI());
     } catch (URISyntaxException e) {
       keyUploadDelegate.onKeyUploadFailed(e);
       return;
@@ -835,7 +835,7 @@ public class GlobalSession implements HttpResponseObserver {
     final GlobalSession self = this;
 
     try {
-      request = new SyncStorageRequest(config.storageURL());
+      request = new SyncStorageRequest(getContext(), config.storageURL());
     } catch (URISyntaxException ex) {
       Logger.warn(LOG_TAG, "Invalid URI in wipeServer.");
       wipeDelegate.onWipeFailed(ex);
@@ -1026,7 +1026,7 @@ public class GlobalSession implements HttpResponseObserver {
       engines.put(engineName, engineSettings.toJSONObject());
     }
 
-    MetaGlobal metaGlobal = new MetaGlobal(metaURL, this.getAuthHeaderProvider());
+    MetaGlobal metaGlobal = new MetaGlobal(getContext(), metaURL, this.getAuthHeaderProvider());
     metaGlobal.setSyncID(newSyncID);
     metaGlobal.setStorageVersion(STORAGE_VERSION);
     metaGlobal.setEngines(engines);

--- a/mobile/android/base/sync/JSONRecordFetcher.java
+++ b/mobile/android/base/sync/JSONRecordFetcher.java
@@ -7,6 +7,8 @@ package org.mozilla.gecko.sync;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import android.content.Context;
+
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.delegates.JSONRecordFetchDelegate;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
@@ -22,14 +24,16 @@ public class JSONRecordFetcher {
   private static final long DEFAULT_AWAIT_TIMEOUT_MSEC = 2 * 60 * 1000;   // Two minutes.
   private static final String LOG_TAG = "JSONRecordFetcher";
 
+  protected final Context mCtx;
   protected final AuthHeaderProvider authHeaderProvider;
   protected final String uri;
   protected JSONRecordFetchDelegate delegate;
 
-  public JSONRecordFetcher(final String uri, final AuthHeaderProvider authHeaderProvider) {
+  public JSONRecordFetcher(final Context ctx, final String uri, final AuthHeaderProvider authHeaderProvider) {
     if (uri == null) {
       throw new IllegalArgumentException("uri must not be null");
     }
+    this.mCtx = ctx;
     this.uri = uri;
     this.authHeaderProvider = authHeaderProvider;
   }
@@ -78,7 +82,7 @@ public class JSONRecordFetcher {
   public void fetch(final JSONRecordFetchDelegate delegate) {
     this.delegate = delegate;
     try {
-      final SyncStorageRecordRequest r = new SyncStorageRecordRequest(this.getURI());
+      final SyncStorageRecordRequest r = new SyncStorageRecordRequest(mCtx, this.getURI());
       r.delegate = new JSONFetchHandler();
       r.get();
     } catch (Exception e) {

--- a/mobile/android/base/sync/MetaGlobal.java
+++ b/mobile/android/base/sync/MetaGlobal.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import android.content.Context;
+
 import org.json.simple.JSONArray;
 import org.json.simple.parser.ParseException;
 import org.mozilla.gecko.background.common.log.Logger;
@@ -25,6 +27,7 @@ import org.mozilla.gecko.sync.net.SyncStorageResponse;
 
 public class MetaGlobal implements SyncStorageRequestDelegate {
   private static final String LOG_TAG = "MetaGlobal";
+  protected final Context mCtx;
   protected String metaURL;
 
   // Fields.
@@ -45,7 +48,8 @@ public class MetaGlobal implements SyncStorageRequestDelegate {
   private boolean isUploading;
   protected final AuthHeaderProvider authHeaderProvider;
 
-  public MetaGlobal(String metaURL, AuthHeaderProvider authHeaderProvider) {
+  public MetaGlobal(Context ctx, String metaURL, AuthHeaderProvider authHeaderProvider) {
+    this.mCtx = ctx;
     this.metaURL = metaURL;
     this.authHeaderProvider = authHeaderProvider;
   }
@@ -54,7 +58,7 @@ public class MetaGlobal implements SyncStorageRequestDelegate {
     this.callback = delegate;
     try {
       this.isUploading = false;
-      SyncStorageRecordRequest r = new SyncStorageRecordRequest(this.metaURL);
+      SyncStorageRecordRequest r = new SyncStorageRecordRequest(this.mCtx, this.metaURL);
       r.delegate = this;
       r.deferGet();
     } catch (URISyntaxException e) {
@@ -65,7 +69,7 @@ public class MetaGlobal implements SyncStorageRequestDelegate {
   public void upload(MetaGlobalDelegate callback) {
     try {
       this.isUploading = true;
-      SyncStorageRecordRequest r = new SyncStorageRecordRequest(this.metaURL);
+      SyncStorageRecordRequest r = new SyncStorageRecordRequest(this.mCtx, this.metaURL);
 
       r.delegate = this;
       this.callback = callback;

--- a/mobile/android/base/sync/MigrationSentinelSyncStage.java
+++ b/mobile/android/base/sync/MigrationSentinelSyncStage.java
@@ -174,7 +174,7 @@ public class MigrationSentinelSyncStage extends AbstractNonRepositorySyncStage {
     public void check() {
       final String url = session.config.storageURL() + META_FXA_CREDENTIALS;
       try {
-        final SyncStorageRecordRequest request = new SyncStorageRecordRequest(url);
+        final SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.getContext(), url);
         request.delegate = new SyncStorageRequestDelegate() {
 
           @Override

--- a/mobile/android/base/sync/PersistedMetaGlobal.java
+++ b/mobile/android/base/sync/PersistedMetaGlobal.java
@@ -7,6 +7,7 @@ package org.mozilla.gecko.sync;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 
 public class PersistedMetaGlobal {
@@ -15,9 +16,11 @@ public class PersistedMetaGlobal {
   public static final String META_GLOBAL_SERVER_RESPONSE_BODY = "metaGlobalServerResponseBody";
   public static final String META_GLOBAL_LAST_MODIFIED        = "metaGlobalLastModified";
 
+  protected Context mCtx;
   protected SharedPreferences prefs;
 
-  public PersistedMetaGlobal(SharedPreferences prefs) {
+  public PersistedMetaGlobal(Context ctx, SharedPreferences prefs) {
+    this.mCtx = ctx;
     this.prefs = prefs;
   }
 
@@ -40,7 +43,7 @@ public class PersistedMetaGlobal {
     MetaGlobal metaGlobal = null;
     try {
       CryptoRecord cryptoRecord = CryptoRecord.fromJSONRecord(json);
-      MetaGlobal mg = new MetaGlobal(metaUrl, authHeaderProvider);
+      MetaGlobal mg = new MetaGlobal(mCtx, metaUrl, authHeaderProvider);
       mg.setFromRecord(cryptoRecord);
       metaGlobal = mg;
     } catch (Exception e) {

--- a/mobile/android/base/sync/Sync11Configuration.java
+++ b/mobile/android/base/sync/Sync11Configuration.java
@@ -10,6 +10,7 @@ import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.crypto.KeyBundle;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
@@ -24,15 +25,17 @@ public class Sync11Configuration extends SyncConfiguration {
 
   public Sync11Configuration(String username,
                              AuthHeaderProvider authHeaderProvider,
+                             Context ctx,
                              SharedPreferences prefs) {
-    super(username, authHeaderProvider, prefs);
+    super(username, authHeaderProvider, ctx, prefs);
   }
 
   public Sync11Configuration(String username,
                              AuthHeaderProvider authHeaderProvider,
+                             Context ctx,
                              SharedPreferences prefs,
                              KeyBundle keyBundle) {
-    super(username, authHeaderProvider, prefs, keyBundle);
+    super(username, authHeaderProvider, ctx, prefs, keyBundle);
   }
 
   @Override

--- a/mobile/android/base/sync/SyncConfiguration.java
+++ b/mobile/android/base/sync/SyncConfiguration.java
@@ -20,6 +20,7 @@ import org.mozilla.gecko.sync.crypto.PersistedCrypto5Keys;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
 import org.mozilla.gecko.sync.stage.GlobalSyncStage.Stage;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
@@ -87,6 +88,7 @@ public class SyncConfiguration {
   public SharedPreferences prefs;
 
   protected final AuthHeaderProvider authHeaderProvider;
+  protected final Context mCtx;
 
   public static final String PREF_PREFS_VERSION = "prefs.version";
   public static final long CURRENT_PREFS_VERSION = 1;
@@ -112,15 +114,16 @@ public class SyncConfiguration {
 
   private static final String API_VERSION = "1.5";
 
-  public SyncConfiguration(String username, AuthHeaderProvider authHeaderProvider, SharedPreferences prefs) {
+  public SyncConfiguration(String username, AuthHeaderProvider authHeaderProvider, Context ctx, SharedPreferences prefs) {
     this.username = username;
     this.authHeaderProvider = authHeaderProvider;
+    this.mCtx = ctx;
     this.prefs = prefs;
     this.loadFromPrefs(prefs);
   }
 
-  public SyncConfiguration(String username, AuthHeaderProvider authHeaderProvider, SharedPreferences prefs, KeyBundle syncKeyBundle) {
-    this(username, authHeaderProvider, prefs);
+  public SyncConfiguration(String username, AuthHeaderProvider authHeaderProvider, Context ctx, SharedPreferences prefs, KeyBundle syncKeyBundle) {
+    this(username, authHeaderProvider, ctx, prefs);
     this.syncKeyBundle = syncKeyBundle;
   }
 
@@ -469,6 +472,6 @@ public class SyncConfiguration {
   }
 
   public PersistedMetaGlobal persistedMetaGlobal() {
-    return new PersistedMetaGlobal(getPrefs());
+    return new PersistedMetaGlobal(mCtx, getPrefs());
   }
 }

--- a/mobile/android/base/sync/config/ClientRecordTerminator.java
+++ b/mobile/android/base/sync/config/ClientRecordTerminator.java
@@ -6,6 +6,8 @@ package org.mozilla.gecko.sync.config;
 
 import java.net.URI;
 
+import android.content.Context;
+
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.SyncConfiguration;
 import org.mozilla.gecko.sync.net.AuthHeaderProvider;
@@ -27,14 +29,14 @@ public class ClientRecordTerminator {
     super(); // Stop this class from being instantiated.
   }
 
-  public static void deleteClientRecord(final SyncConfiguration config, final String clientGUID)
+  public static void deleteClientRecord(final Context context, final SyncConfiguration config, final String clientGUID)
     throws Exception {
 
     final String collection = "clients";
     final URI wboURI = config.wboURI(collection, clientGUID);
 
     // Would prefer to break this out into a self-contained client library.
-    final SyncStorageRecordRequest r = new SyncStorageRecordRequest(wboURI);
+    final SyncStorageRecordRequest r = new SyncStorageRecordRequest(context, wboURI);
     r.delegate = new SyncStorageRequestDelegate() {
       @Override
       public AuthHeaderProvider getAuthHeaderProvider() {

--- a/mobile/android/base/sync/jpake/JPakeClient.java
+++ b/mobile/android/base/sync/jpake/JPakeClient.java
@@ -9,6 +9,8 @@ import java.math.BigInteger;
 import java.util.LinkedList;
 import java.util.Queue;
 
+import android.content.Context;
+
 import org.json.simple.JSONObject;
 import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.background.common.log.Logger;
@@ -83,6 +85,7 @@ public class JPakeClient {
 
   public JPakeParty jParty;
   public final JPakeNumGenerator numGen;
+  public final Context context;
 
   public int pollTries;
 
@@ -92,6 +95,7 @@ public class JPakeClient {
 
   public JPakeClient(SetupSyncActivity activity) {
     controllerActivity = activity;
+    context = activity;
     jpakeServer = "https://setup.services.mozilla.com/";
     jpakePollInterval = 1 * 1000; // 1 second
     jpakeMaxTries = MAX_TRIES;

--- a/mobile/android/base/sync/jpake/stage/DeleteChannel.java
+++ b/mobile/android/base/sync/jpake/stage/DeleteChannel.java
@@ -30,7 +30,7 @@ public class DeleteChannel {
   public void execute(final JPakeClient jClient, final String reason) {
     final BaseResource httpResource;
     try {
-      httpResource = new BaseResource(jClient.channelUrl);
+      httpResource = new BaseResource(jClient.context, jClient.channelUrl);
     } catch (URISyntaxException e) {
       Logger.debug(LOG_TAG, "Encountered URISyntax exception, displaying abort anyway.");
       jClient.displayAbort(reason);

--- a/mobile/android/base/sync/jpake/stage/GetChannelStage.java
+++ b/mobile/android/base/sync/jpake/stage/GetChannelStage.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import android.content.Context;
+
 import org.json.simple.parser.JSONParser;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.SyncConstants;
@@ -66,7 +68,7 @@ public class GetChannelStage extends JPakeStage {
     };
 
     try {
-      makeChannelRequest(callbackDelegate, jClient.jpakeServer + "new_channel", jClient.clientId);
+      makeChannelRequest(jClient.context, callbackDelegate, jClient.jpakeServer + "new_channel", jClient.clientId);
     } catch (URISyntaxException e) {
       Logger.error(LOG_TAG, "Incorrect URI syntax.", e);
       jClient.abort(Constants.JPAKE_ERROR_CHANNEL);
@@ -78,8 +80,8 @@ public class GetChannelStage extends JPakeStage {
     }
   }
 
-  private void makeChannelRequest(final GetChannelStageDelegate callbackDelegate, String getChannelUrl, final String clientId) throws URISyntaxException {
-    final BaseResource httpResource = new BaseResource(getChannelUrl);
+  private void makeChannelRequest(final Context context, final GetChannelStageDelegate callbackDelegate, String getChannelUrl, final String clientId) throws URISyntaxException {
+    final BaseResource httpResource = new BaseResource(context, getChannelUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/jpake/stage/GetRequestStage.java
+++ b/mobile/android/base/sync/jpake/stage/GetRequestStage.java
@@ -100,7 +100,7 @@ public class GetRequestStage extends JPakeStage {
   }
 
   private Resource createGetRequest(final GetRequestStageDelegate callbackDelegate, final JPakeClient jpakeClient) throws URISyntaxException {
-    BaseResource httpResource = new BaseResource(jpakeClient.channelUrl);
+    BaseResource httpResource = new BaseResource(jpakeClient.context, jpakeClient.channelUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/jpake/stage/PutRequestStage.java
+++ b/mobile/android/base/sync/jpake/stage/PutRequestStage.java
@@ -91,7 +91,7 @@ public class PutRequestStage extends JPakeStage {
   }
 
   private Resource createPutRequest(final PutRequestStageDelegate callbackDelegate, final JPakeClient jpakeClient) throws URISyntaxException {
-    BaseResource httpResource = new BaseResource(jpakeClient.channelUrl);
+    BaseResource httpResource = new BaseResource(jpakeClient.context, jpakeClient.channelUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/net/BaseResource.java
+++ b/mobile/android/base/sync/net/BaseResource.java
@@ -21,6 +21,7 @@ import javax.net.ssl.SSLContext;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.mozilla.gecko.background.common.log.Logger;
+import org.mozilla.gecko.util.ProxyRoutePlanner;
 import org.mozilla.gecko.sync.ExtendedJSONObject;
 
 import ch.boye.httpclientandroidlib.Header;
@@ -52,8 +53,6 @@ import ch.boye.httpclientandroidlib.params.HttpProtocolParams;
 import ch.boye.httpclientandroidlib.protocol.BasicHttpContext;
 import ch.boye.httpclientandroidlib.protocol.HttpContext;
 import ch.boye.httpclientandroidlib.util.EntityUtils;
-import ch.boye.httpclientandroidlib.HttpHost;
-import ch.boye.httpclientandroidlib.conn.params.ConnRoutePNames;
 
 /**
  * Provide simple HTTP access to a Sync server or similar.
@@ -183,8 +182,7 @@ public class BaseResource implements Resource {
     // We could reuse these client instances, except that we mess around
     // with their parameters… so we'd need a pool of some kind.
     client = new DefaultHttpClient(getConnectionManager());
-    HttpHost torProxy = new HttpHost("127.0.0.1", 8118);
-    client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, torProxy);
+    client.setRoutePlanner(new ProxyRoutePlanner());
 
     // TODO: Eventually we should use Apache HttpAsyncClient. It's not out of alpha yet.
     // Until then, we synchronously make the request, then invoke our delegate's callback.

--- a/mobile/android/base/sync/net/BaseResource.java
+++ b/mobile/android/base/sync/net/BaseResource.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.net;
 
+import android.content.Context;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -73,6 +75,7 @@ public class BaseResource implements Resource {
 
   private static final String LOG_TAG = "BaseResource";
 
+  protected final Context mCtx;
   protected final URI uri;
   protected BasicHttpContext context;
   protected DefaultHttpClient client;
@@ -88,19 +91,21 @@ public class BaseResource implements Resource {
   protected static final CopyOnWriteArrayList<WeakReference<HttpResponseObserver>>
     httpResponseObservers = new CopyOnWriteArrayList<>();
 
-  public BaseResource(String uri) throws URISyntaxException {
-    this(uri, rewriteLocalhost);
+  public BaseResource(Context ctx, String uri) throws URISyntaxException {
+    this(ctx, uri, rewriteLocalhost);
   }
 
-  public BaseResource(URI uri) {
-    this(uri, rewriteLocalhost);
+  public BaseResource(Context ctx, URI uri) {
+    this(ctx, uri, rewriteLocalhost);
   }
 
-  public BaseResource(String uri, boolean rewrite) throws URISyntaxException {
-    this(new URI(uri), rewrite);
+  public BaseResource(Context ctx, String uri, boolean rewrite) throws URISyntaxException {
+    this(ctx, new URI(uri), rewrite);
   }
 
-  public BaseResource(URI uri, boolean rewrite) {
+  public BaseResource(Context ctx, URI uri, boolean rewrite) {
+    this.mCtx = ctx;
+
     if (uri == null) {
       throw new IllegalArgumentException("uri must not be null");
     }

--- a/mobile/android/base/sync/net/SyncStorageCollectionRequest.java
+++ b/mobile/android/base/sync/net/SyncStorageCollectionRequest.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.net;
 
+import android.content.Context;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,8 +31,8 @@ import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
 public class SyncStorageCollectionRequest extends SyncStorageRequest {
   private static final String LOG_TAG = "CollectionRequest";
 
-  public SyncStorageCollectionRequest(URI uri) {
-    super(uri);
+  public SyncStorageCollectionRequest(Context context, URI uri) {
+    super(context, uri);
   }
 
   protected volatile boolean aborting = false;

--- a/mobile/android/base/sync/net/SyncStorageRecordRequest.java
+++ b/mobile/android/base/sync/net/SyncStorageRecordRequest.java
@@ -8,6 +8,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import android.content.Context;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.mozilla.gecko.sync.CryptoRecord;
@@ -42,12 +44,12 @@ public class SyncStorageRecordRequest extends SyncStorageRequest {
     }
   }
 
-  public SyncStorageRecordRequest(URI uri) {
-    super(uri);
+  public SyncStorageRecordRequest(Context context, URI uri) {
+    super(context, uri);
   }
 
-  public SyncStorageRecordRequest(String url) throws URISyntaxException {
-    this(new URI(url));
+  public SyncStorageRecordRequest(Context context, String url) throws URISyntaxException {
+    this(context, new URI(url));
   }
 
   @Override

--- a/mobile/android/base/sync/net/SyncStorageRequest.java
+++ b/mobile/android/base/sync/net/SyncStorageRequest.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.net;
 
+import android.content.Context;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,15 +66,15 @@ public class SyncStorageRequest implements Resource {
    * @param uri
    * @throws URISyntaxException
    */
-  public SyncStorageRequest(String uri) throws URISyntaxException {
-    this(new URI(uri));
+  public SyncStorageRequest(Context ctx, String uri) throws URISyntaxException {
+    this(ctx, new URI(uri));
   }
 
   /**
    * @param uri
    */
-  public SyncStorageRequest(URI uri) {
-    this.resource = new BaseResource(uri);
+  public SyncStorageRequest(Context ctx, URI uri) {
+    this.resource = new BaseResource(ctx, uri);
     this.resourceDelegate = this.makeResourceDelegate(this);
     this.resource.delegate = this.resourceDelegate;
   }

--- a/mobile/android/base/sync/receivers/SyncAccountDeletedService.java
+++ b/mobile/android/base/sync/receivers/SyncAccountDeletedService.java
@@ -133,14 +133,14 @@ public class SyncAccountDeletedService extends IntentService {
       }
 
       BasicAuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(encodedUsername, password);
-      SyncConfiguration configuration = new Sync11Configuration(encodedUsername, authHeaderProvider, prefs);
+      SyncConfiguration configuration = new Sync11Configuration(encodedUsername, authHeaderProvider, context, prefs);
       if (configuration.getClusterURL() == null) {
         Logger.warn(LOG_TAG, "Cluster URL was null; not deleting client record from server.");
         return;
       }
 
       try {
-        ClientRecordTerminator.deleteClientRecord(configuration, clientGUID);
+        ClientRecordTerminator.deleteClientRecord(context, configuration, clientGUID);
       } catch (Exception e) {
         // This should never happen, but we really don't want to die in a background thread.
         Logger.warn(LOG_TAG, "Got exception deleting client record from server; ignoring.", e);

--- a/mobile/android/base/sync/repositories/Server11Repository.java
+++ b/mobile/android/base/sync/repositories/Server11Repository.java
@@ -55,7 +55,7 @@ public class Server11Repository extends Repository {
   @Override
   public void createSession(RepositorySessionCreationDelegate delegate,
                             Context context) {
-    delegate.onSessionCreated(new Server11RepositorySession(this));
+    delegate.onSessionCreated(new Server11RepositorySession(this, context));
   }
 
   public URI collectionURI() {

--- a/mobile/android/base/sync/setup/auth/AccountAuthenticator.java
+++ b/mobile/android/base/sync/setup/auth/AccountAuthenticator.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.sync.setup.auth;
 
+import android.content.Context;
+
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -18,6 +20,8 @@ public class AccountAuthenticator {
   private final AccountActivity activityCallback;
   private Queue<AuthenticatorStage> stages;
 
+  public final Context context;
+
   // Values for authentication.
   public String password;
   public String username;
@@ -30,6 +34,7 @@ public class AccountAuthenticator {
 
   public AccountAuthenticator(AccountActivity activity) {
     activityCallback = activity;
+    context = activity;
     prepareStages();
   }
 

--- a/mobile/android/base/sync/setup/auth/AuthenticateAccountStage.java
+++ b/mobile/android/base/sync/setup/auth/AuthenticateAccountStage.java
@@ -12,6 +12,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import android.content.Context;
+
 import org.mozilla.apache.commons.codec.binary.Base64;
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.SyncConstants;
@@ -78,7 +80,7 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
     String authRequestUrl = makeAuthRequestUrl(aa.authServer, aa.username);
     // Might contain plaintext username for old Sync accounts.
     Logger.pii(LOG_TAG, "Making auth request to: " + authRequestUrl);
-    authenticateAccount(callbackDelegate, authRequestUrl, authHeader);
+    authenticateAccount(aa.context, callbackDelegate, authRequestUrl, authHeader);
 
   }
 
@@ -91,8 +93,8 @@ public class AuthenticateAccountStage implements AuthenticatorStage {
    * @throws URISyntaxException
    */
   // Made public for testing.
-  public void authenticateAccount(final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {
-    final BaseResource httpResource = new BaseResource(authRequestUrl);
+  public void authenticateAccount(final Context context, final AuthenticateAccountStageDelegate callbackDelegate, final String authRequestUrl, final String authHeader) throws URISyntaxException {
+    final BaseResource httpResource = new BaseResource(context, authRequestUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/setup/auth/EnsureUserExistenceStage.java
+++ b/mobile/android/base/sync/setup/auth/EnsureUserExistenceStage.java
@@ -55,7 +55,7 @@ public class EnsureUserExistenceStage implements AuthenticatorStage {
 
     // This is not the same as Utils.nodeWeaveURL: it's missing the trailing node/weave.
     String userRequestUrl = aa.nodeServer + "user/1.0/" + aa.username;
-    final BaseResource httpResource = new BaseResource(userRequestUrl);
+    final BaseResource httpResource = new BaseResource(aa.context, userRequestUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/setup/auth/FetchUserNodeStage.java
+++ b/mobile/android/base/sync/setup/auth/FetchUserNodeStage.java
@@ -11,6 +11,8 @@ import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import android.content.Context;
+
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.SyncConstants;
 import org.mozilla.gecko.sync.Utils;
@@ -65,7 +67,7 @@ public class FetchUserNodeStage implements AuthenticatorStage {
     String nodeRequestUrl = Utils.nodeWeaveURL(aa.nodeServer, aa.username);
     // Might contain a plaintext username in the case of old Sync accounts.
     Logger.pii(LOG_TAG, "NodeUrl: " + nodeRequestUrl);
-    final BaseResource httpResource = makeFetchNodeRequest(callbackDelegate, nodeRequestUrl);
+    final BaseResource httpResource = makeFetchNodeRequest(aa.context, callbackDelegate, nodeRequestUrl);
     // Make request on separate thread.
     AccountAuthenticator.runOnThread(new Runnable() {
       @Override
@@ -75,9 +77,9 @@ public class FetchUserNodeStage implements AuthenticatorStage {
     });
   }
 
-  private BaseResource makeFetchNodeRequest(final FetchNodeStageDelegate callbackDelegate, String fetchNodeUrl) throws URISyntaxException {
+  private BaseResource makeFetchNodeRequest(final Context context, final FetchNodeStageDelegate callbackDelegate, String fetchNodeUrl) throws URISyntaxException {
     // Fetch node containing user.
-    final BaseResource httpResource = new BaseResource(fetchNodeUrl);
+    final BaseResource httpResource = new BaseResource(context, fetchNodeUrl);
     httpResource.delegate = new BaseResourceDelegate(httpResource) {
       @Override
       public String getUserAgent() {

--- a/mobile/android/base/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
+++ b/mobile/android/base/sync/stage/AndroidBrowserBookmarksServerSyncStage.java
@@ -43,7 +43,7 @@ public class AndroidBrowserBookmarksServerSyncStage extends ServerSyncStage {
     // If this is a first sync, we need to check server counts to make sure that we aren't
     // going to screw up. SafeConstrainedServer11Repository does this. See Bug 814331.
     AuthHeaderProvider authHeaderProvider = session.getAuthHeaderProvider();
-    final JSONRecordFetcher countsFetcher = new JSONRecordFetcher(session.config.infoCollectionCountsURL(), authHeaderProvider);
+    final JSONRecordFetcher countsFetcher = new JSONRecordFetcher(session.getContext(), session.config.infoCollectionCountsURL(), authHeaderProvider);
     String collection = getCollection();
     return new SafeConstrainedServer11Repository(
         collection,

--- a/mobile/android/base/sync/stage/EnsureClusterURLStage.java
+++ b/mobile/android/base/sync/stage/EnsureClusterURLStage.java
@@ -12,6 +12,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 
+import android.content.Context;
+
 import org.mozilla.gecko.background.common.log.Logger;
 import org.mozilla.gecko.sync.NodeAuthenticationException;
 import org.mozilla.gecko.sync.NullClusterURLException;
@@ -71,11 +73,12 @@ public class EnsureClusterURLStage extends AbstractNonRepositorySyncStage {
    *          <code>https://server/pathname/version/username/node/weave</code>.
    * @throws URISyntaxException
    */
-  public static void fetchClusterURL(final String nodeWeaveURL,
+  public static void fetchClusterURL(final Context context,
+                                     final String nodeWeaveURL,
                                      final ClusterURLFetchDelegate delegate) throws URISyntaxException {
     Logger.info(LOG_TAG, "In fetchClusterURL: node/weave is " + nodeWeaveURL);
 
-    BaseResource resource = new BaseResource(nodeWeaveURL);
+    BaseResource resource = new BaseResource(context, nodeWeaveURL);
     resource.delegate = new BaseResourceDelegate(resource) {
       @Override
       public String getUserAgent() {
@@ -251,7 +254,7 @@ public class EnsureClusterURLStage extends AbstractNonRepositorySyncStage {
       @Override
       public void run() {
         try {
-          fetchClusterURL(callback.nodeWeaveURL(), delegate);
+          fetchClusterURL(session.getContext(), callback.nodeWeaveURL(), delegate);
         } catch (URISyntaxException e) {
           session.abort(e, "Invalid URL for node/weave.");
         }

--- a/mobile/android/base/sync/stage/EnsureCrypto5KeysStage.java
+++ b/mobile/android/base/sync/stage/EnsureCrypto5KeysStage.java
@@ -55,7 +55,7 @@ implements SyncStorageRequestDelegate {
     // We need an update: fetch fresh keys.
     Logger.debug(LOG_TAG, "Fetching fresh collection keys for this session.");
     try {
-      SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.wboURI(CRYPTO_COLLECTION, "keys"));
+      SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.getContext(), session.wboURI(CRYPTO_COLLECTION, "keys"));
       request.delegate = this;
       request.get();
     } catch (URISyntaxException e) {

--- a/mobile/android/base/sync/stage/FetchMetaGlobalStage.java
+++ b/mobile/android/base/sync/stage/FetchMetaGlobalStage.java
@@ -73,7 +73,7 @@ public class FetchMetaGlobalStage extends AbstractNonRepositorySyncStage {
 
     // We need an update: fetch or upload meta/global as necessary.
     Logger.info(LOG_TAG, "Fetching fresh meta/global for this session.");
-    MetaGlobal global = new MetaGlobal(session.config.metaURL(), session.getAuthHeaderProvider());
+    MetaGlobal global = new MetaGlobal(session.getContext(), session.config.metaURL(), session.getAuthHeaderProvider());
     global.fetch(new StageMetaGlobalDelegate(session));
   }
 }

--- a/mobile/android/base/sync/stage/SafeConstrainedServer11Repository.java
+++ b/mobile/android/base/sync/stage/SafeConstrainedServer11Repository.java
@@ -51,7 +51,7 @@ public class SafeConstrainedServer11Repository extends ConstrainedServer11Reposi
   @Override
   public void createSession(RepositorySessionCreationDelegate delegate,
                             Context context) {
-    delegate.onSessionCreated(new CountCheckingServer11RepositorySession(this, this.getDefaultFetchLimit()));
+    delegate.onSessionCreated(new CountCheckingServer11RepositorySession(this, context, this.getDefaultFetchLimit()));
   }
 
   public class CountCheckingServer11RepositorySession extends Server11RepositorySession {
@@ -63,8 +63,8 @@ public class SafeConstrainedServer11Repository extends ConstrainedServer11Reposi
      */
     private final long fetchLimit;
 
-    public CountCheckingServer11RepositorySession(Repository repository, long fetchLimit) {
-      super(repository);
+    public CountCheckingServer11RepositorySession(Repository repository, Context context, long fetchLimit) {
+      super(repository, context);
       this.fetchLimit = fetchLimit;
     }
 

--- a/mobile/android/base/sync/stage/ServerSyncStage.java
+++ b/mobile/android/base/sync/stage/ServerSyncStage.java
@@ -376,7 +376,7 @@ public abstract class ServerSyncStage extends AbstractSessionManagingSyncStage i
     SyncStorageRequest request;
 
     try {
-      request = new SyncStorageRequest(session.config.collectionURI(getCollection()));
+      request = new SyncStorageRequest(session.getContext(), session.config.collectionURI(getCollection()));
     } catch (URISyntaxException ex) {
       Logger.warn(LOG_TAG, "Invalid URI in wipeServer.");
       wipeDelegate.onWipeFailed(ex);

--- a/mobile/android/base/sync/stage/SyncClientsEngineStage.java
+++ b/mobile/android/base/sync/stage/SyncClientsEngineStage.java
@@ -543,7 +543,7 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
 
     try {
       final URI getURI = session.config.collectionURI(COLLECTION_NAME, true);
-      final SyncStorageCollectionRequest request = new SyncStorageCollectionRequest(getURI);
+      final SyncStorageCollectionRequest request = new SyncStorageCollectionRequest(session.getContext(), getURI);
       request.delegate = clientDownloadDelegate;
 
       Logger.trace(LOG_TAG, "Downloading client records.");
@@ -557,7 +557,7 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
     Logger.trace(LOG_TAG, "Uploading " + records.size() + " client records.");
     try {
       final URI postURI = session.config.collectionURI(COLLECTION_NAME, false);
-      final SyncStorageRecordRequest request = new SyncStorageRecordRequest(postURI);
+      final SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.getContext(), postURI);
       request.delegate = clientUploadDelegate;
       request.post(records);
     } catch (URISyntaxException e) {
@@ -574,7 +574,7 @@ public class SyncClientsEngineStage extends AbstractSessionManagingSyncStage {
     Logger.debug(LOG_TAG, "Uploading client record " + record.guid);
     try {
       final URI postURI = session.config.collectionURI(COLLECTION_NAME);
-      final SyncStorageRecordRequest request = new SyncStorageRecordRequest(postURI);
+      final SyncStorageRecordRequest request = new SyncStorageRecordRequest(session.getContext(), postURI);
       request.delegate = clientUploadDelegate;
       request.post(record);
     } catch (URISyntaxException e) {

--- a/mobile/android/base/sync/syncadapter/SyncAdapter.java
+++ b/mobile/android/base/sync/syncadapter/SyncAdapter.java
@@ -513,7 +513,7 @@ public class SyncAdapter extends AbstractThreadedSyncAdapter implements BaseGlob
 
     final AuthHeaderProvider authHeaderProvider = new BasicAuthHeaderProvider(username, password);
     final SharedPreferences prefs = getContext().getSharedPreferences(prefsPath, Utils.SHARED_PREFERENCES_MODE);
-    final SyncConfiguration config = new Sync11Configuration(username, authHeaderProvider, prefs, keyBundle);
+    final SyncConfiguration config = new Sync11Configuration(username, authHeaderProvider, this.mContext, prefs, keyBundle);
 
     Collection<String> knownStageNames = SyncConfiguration.validEngineNames();
     config.stagesToSync = Utils.getStagesToSyncFromBundle(knownStageNames, extras);

--- a/mobile/android/base/tokenserver/TokenServerClient.java
+++ b/mobile/android/base/tokenserver/TokenServerClient.java
@@ -4,6 +4,8 @@
 
 package org.mozilla.gecko.tokenserver;
 
+import android.content.Context;
+
 import java.io.IOException;
 import java.net.URI;
 import java.security.GeneralSecurityException;
@@ -320,8 +322,9 @@ public class TokenServerClient {
   public void getTokenFromBrowserIDAssertion(final String assertion,
                                              final boolean conditionsAccepted,
                                              final String clientState,
-                                             final TokenServerClientDelegate delegate) {
-    final BaseResource resource = new BaseResource(this.uri);
+                                             final TokenServerClientDelegate delegate,
+                                             final Context context) {
+    final BaseResource resource = new BaseResource(context, this.uri);
     resource.delegate = new TokenFetchResourceDelegate(this, resource, delegate,
                                                        assertion, clientState,
                                                        conditionsAccepted);

--- a/mobile/android/base/util/ProxyRoutePlanner.java
+++ b/mobile/android/base/util/ProxyRoutePlanner.java
@@ -1,0 +1,23 @@
+package org.mozilla.gecko.util;
+
+import ch.boye.httpclientandroidlib.HttpException;
+import ch.boye.httpclientandroidlib.HttpHost;
+import ch.boye.httpclientandroidlib.HttpRequest;
+import ch.boye.httpclientandroidlib.impl.conn.DefaultRoutePlanner;
+import ch.boye.httpclientandroidlib.impl.conn.DefaultSchemePortResolver;
+import ch.boye.httpclientandroidlib.protocol.HttpContext;
+
+public class ProxyRoutePlanner extends DefaultRoutePlanner {
+    public ProxyRoutePlanner() {
+        super(DefaultSchemePortResolver.INSTANCE);
+    }
+
+    @Override
+    protected HttpHost determineProxy(
+            final HttpHost target,
+            final HttpRequest request,
+            final HttpContext context) throws HttpException {
+        // TODO multiple proxies handling different domains
+        return ProxySettings.getProxyHost();
+    }
+}

--- a/mobile/android/base/util/ProxySettings.java
+++ b/mobile/android/base/util/ProxySettings.java
@@ -1,0 +1,21 @@
+package org.mozilla.gecko.util;
+
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
+import ch.boye.httpclientandroidlib.HttpHost;
+
+public class ProxySettings {
+    private static final String TOR_PROXY_ADDRESS = "127.0.0.1";
+    private static final int TOR_PROXY_PORT = 8118;
+
+    public static Proxy getProxy() {
+        // TODO make configurable
+        return new Proxy(Proxy.Type.HTTP, new InetSocketAddress(TOR_PROXY_ADDRESS, TOR_PROXY_PORT));
+    }
+
+    public static HttpHost getProxyHost() {
+        // TODO make configurable
+        return new HttpHost(TOR_PROXY_ADDRESS, TOR_PROXY_PORT);
+    }
+}

--- a/mobile/android/search/java/org/mozilla/search/providers/SearchEngineManager.java
+++ b/mobile/android/search/java/org/mozilla/search/providers/SearchEngineManager.java
@@ -16,6 +16,7 @@ import org.mozilla.gecko.GeckoSharedPrefs;
 import org.mozilla.gecko.Locales;
 import org.mozilla.gecko.R;
 import org.mozilla.gecko.distribution.Distribution;
+import org.mozilla.gecko.util.ProxySettings;
 import org.mozilla.gecko.util.FileUtils;
 import org.mozilla.gecko.util.GeckoJarReader;
 import org.mozilla.gecko.util.HardwareUtils;
@@ -34,8 +35,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.Proxy;
-import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Locale;
@@ -329,8 +328,8 @@ public class SearchEngineManager implements SharedPreferences.OnSharedPreference
             String responseText = null;
 
             URL url = new URL(GEOIP_LOCATION_URL);
-            Proxy torProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
-            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection(torProxy);
+            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection(
+                    ProxySettings.getProxy());
             try {
                 // POST an empty JSON object.
                 final String message = "{}";

--- a/mobile/android/stumbler/java/org/mozilla/mozstumbler/service/utils/AbstractCommunicator.java
+++ b/mobile/android/stumbler/java/org/mozilla/mozstumbler/service/utils/AbstractCommunicator.java
@@ -75,6 +75,7 @@ public abstract class AbstractCommunicator {
                 sMozApiKey = prefs.getMozApiKey();
             }
             URL url = new URL(getUrlString() + "?key=" + sMozApiKey);
+            // TODO are we allowed to link to code in base?
             Proxy torProxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress("127.0.0.1", 8118));
             mHttpURLConnection = (HttpURLConnection) url.openConnection(torProxy);
             mHttpURLConnection.setRequestMethod("POST");


### PR DESCRIPTION
Currently includes these changes:
- Bundle NetCipher (with minor changes).
- Use `StrongHttpsClient` instead of `DefaultHttpClient`.
  - I had wanted to move to using an `HttpRoutePlanner` but the issues with HttpClient 4.3 (lacking SOCKS4a/5 and lacking any way to overload the newer APIs until 4.4) mean that we have to stick with the deprecated API.
- Centralize proxy settings in `org.mozilla.gecko.util.ProxySettings`.

Moving to SOCKS can now be done for everything that uses `StrongHttpsClient`, by altering `ProxySettings.setProxy()`. However, I am concerned that the code using `URL.openConnection()` (and calling `ProxySettings.getProxy()`) might need to be migrated to `StrongHttpsClient` too? I haven't yet figured out how to overload that to add SOCKS4a/5 support, but rewriting the code that uses it to use HttpClient will be a mammoth undertaking, and make it much more difficult to pull in upstream changes. So overloading `URL.openConnection()` would be preferable.
